### PR TITLE
CORS 설정 수정

### DIFF
--- a/src/main/java/kr/ac/kumoh/likelion/bouquet/global/config/security/CorsConfig.java
+++ b/src/main/java/kr/ac/kumoh/likelion/bouquet/global/config/security/CorsConfig.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class CorsConfig {
     public static CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:8080", "http://localhost:5000"));
+        configuration.setAllowedOrigins(List.of("http://localhost:8080", "http://localhost:3000", "https://likelion.patulus.com"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setMaxAge(3600L);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,7 +26,7 @@ spring:
         default_batch_fetch_size: 100
     open-in-view: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
   security:
     oauth2:
       client:


### PR DESCRIPTION
## 🚩 작업 요약
**1️⃣ CORS 설정 수정**
- CORS는 다른 도메인에서 API 서버의 리소스에 접근할 수 있도록 하는 브라우저의 기능으로, 프론트엔드 `localhost:3000`에서 접근할 수 있도록 수정했습니다.