### PR TITLE
주문 및 리뷰 도메인 구현

### DIFF
--- a/src/main/java/kr/ac/kumoh/likelion/bouquet/color/controller/ColorController.java
+++ b/src/main/java/kr/ac/kumoh/likelion/bouquet/color/controller/ColorController.java
@@ -1,8 +1,19 @@
 package kr.ac.kumoh.likelion.bouquet.color.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.ac.kumoh.likelion.bouquet.color.dto.ColorResponse;
 import kr.ac.kumoh.likelion.bouquet.color.service.ColorService;
+import kr.ac.kumoh.likelion.bouquet.global.base.dto.ResponseBody;
+import kr.ac.kumoh.likelion.bouquet.global.base.dto.ResponseUtils;
+import kr.ac.kumoh.likelion.bouquet.global.base.exception.ErrorCode;
+import kr.ac.kumoh.likelion.bouquet.global.config.swagger.SwaggerApiFailedResponse;
+import kr.ac.kumoh.likelion.bouquet.global.config.swagger.SwaggerApiResponses;
+import kr.ac.kumoh.likelion.bouquet.global.config.swagger.SwaggerApiSuccessResponse;
+import kr.ac.kumoh.likelion.bouquet.user.dto.UserProfileResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,9 +30,20 @@ public class ColorController {
 
     private final ColorService colorService;
 
+    @Operation(
+            summary = "꽃 색상 정보 조회",
+            description = "꽃 색상 정보를 조회합니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ColorResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "꽃 색상 정보 조회에 성공했습니다.",
+                    response = ColorResponse[].class
+            )
+    )
     @GetMapping
-    public ResponseEntity<List<ColorResponse>> getColors() {
+    public ResponseEntity<ResponseBody<List<ColorResponse>>> getColors() {
         List<ColorResponse> colors = colorService.findAllColors();
-        return ResponseEntity.ok(colors);
+        return ResponseEntity.ok(ResponseUtils.createSuccessResponse(colors));
     }
 }

--- a/src/main/java/kr/ac/kumoh/likelion/bouquet/flower/controller/FlowerController.java
+++ b/src/main/java/kr/ac/kumoh/likelion/bouquet/flower/controller/FlowerController.java
@@ -1,10 +1,19 @@
 package kr.ac.kumoh.likelion.bouquet.flower.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.ac.kumoh.likelion.bouquet.color.dto.ColorResponse;
 import kr.ac.kumoh.likelion.bouquet.flower.dto.FlowerCreateRequest;
 import kr.ac.kumoh.likelion.bouquet.flower.dto.FlowerDetailResponse;
 import kr.ac.kumoh.likelion.bouquet.flower.dto.FlowerSummaryResponse;
 import kr.ac.kumoh.likelion.bouquet.flower.service.FlowerService;
+import kr.ac.kumoh.likelion.bouquet.global.base.dto.ResponseBody;
+import kr.ac.kumoh.likelion.bouquet.global.base.dto.ResponseUtils;
+import kr.ac.kumoh.likelion.bouquet.global.config.swagger.SwaggerApiResponses;
+import kr.ac.kumoh.likelion.bouquet.global.config.swagger.SwaggerApiSuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "꽃")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/flowers")
@@ -19,20 +29,53 @@ public class FlowerController {
 
     private final FlowerService flowerService;
 
+    @Operation(
+            summary = "꽃 목록 조회",
+            description = "꽃 목록을 조회합니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ColorResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "꽃 목록 조회에 성공했습니다.",
+                    response = ColorResponse[].class
+            )
+    )
     @GetMapping
-    public ResponseEntity<List<FlowerSummaryResponse>> getFlowers(
+    public ResponseEntity<ResponseBody<List<FlowerSummaryResponse>>> getFlowers(
             @RequestParam(required = false) Long colorId,
             @RequestParam(required = false) Integer month) {
         List<FlowerSummaryResponse> flowers = flowerService.findFlowers(colorId, month);
-        return ResponseEntity.ok(flowers);
+        return ResponseEntity.ok(ResponseUtils.createSuccessResponse(flowers));
     }
 
+    @Operation(
+            summary = "꽃 정보 조회",
+            description = "꽃 정보를 조회합니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = FlowerDetailResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "꽃 정보 조회에 성공했습니다.",
+                    response = FlowerDetailResponse.class
+            )
+    )
     @GetMapping("/{flowerId}")
     public ResponseEntity<FlowerDetailResponse> getFlowerDetail(@PathVariable Long flowerId) {
         FlowerDetailResponse flower = flowerService.findFlowerById(flowerId);
         return ResponseEntity.ok(flower);
     }
 
+    @Operation(
+            summary = "꽃에 어울리는 색상 목록 조회",
+            description = "꽃에 어울리는 색상 목록을 조회합니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = FlowerDetailResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "꽃에 어울리는 색상 목록 조회에 성공했습니다.",
+                    response = FlowerDetailResponse[].class
+            )
+    )
     @GetMapping("/{flowerId}/matching-colors")
     public ResponseEntity<List<ColorResponse>> getMatchingColors(@PathVariable Long flowerId) {
         List<ColorResponse> colors = flowerService.findMatchingColorsByFlowerId(flowerId);

--- a/src/main/java/kr/ac/kumoh/likelion/bouquet/global/config/swagger/SwaggerApiSuccessResponseHandler.java
+++ b/src/main/java/kr/ac/kumoh/likelion/bouquet/global/config/swagger/SwaggerApiSuccessResponseHandler.java
@@ -36,6 +36,7 @@ public class SwaggerApiSuccessResponseHandler {
         // 기본 응답 및 200 HTTP 응답 상태 코드 삭제
         String responseCode = String.valueOf(apiSuccessResponse.status().value());
         responses.remove("default");
+        responses.remove("200");
         responses.remove(responseCode);
 
         // 공통 응답 스키마 구성

--- a/src/main/java/kr/ac/kumoh/likelion/bouquet/order/controller/OrderController.java
+++ b/src/main/java/kr/ac/kumoh/likelion/bouquet/order/controller/OrderController.java
@@ -1,13 +1,21 @@
 package kr.ac.kumoh.likelion.bouquet.order.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.ac.kumoh.likelion.bouquet.flower.dto.FlowerDetailResponse;
 import kr.ac.kumoh.likelion.bouquet.global.base.dto.ResponseBody;
 import kr.ac.kumoh.likelion.bouquet.global.base.dto.ResponseUtils;
+import kr.ac.kumoh.likelion.bouquet.global.config.swagger.SwaggerApiResponses;
+import kr.ac.kumoh.likelion.bouquet.global.config.swagger.SwaggerApiSuccessResponse;
 import kr.ac.kumoh.likelion.bouquet.global.jwt.annotation.CurrentUserId;
 import kr.ac.kumoh.likelion.bouquet.order.dto.OrderRequest;
 import kr.ac.kumoh.likelion.bouquet.order.dto.OrderResponse;
 import kr.ac.kumoh.likelion.bouquet.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,27 +34,71 @@ import java.util.List;
 public class OrderController {
     private final OrderService orderService;
 
+    @Operation(
+            summary = "주문",
+            description = "꽃집에서 꽃들을 주문합니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = OrderResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "주문에 성공했습니다.",
+                    response = OrderResponse.class
+            )
+    )
     @PostMapping
-    public ResponseEntity<ResponseBody<OrderResponse>> save(@CurrentUserId Long userId,
+    public ResponseEntity<ResponseBody<OrderResponse>> createOrder(@CurrentUserId Long userId,
                                                             @RequestBody OrderRequest orderRequest) {
-        return ResponseEntity.ok(ResponseUtils.createSuccessResponse(orderService.save(userId, orderRequest)));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ResponseUtils.createSuccessResponse(orderService.createOrder(userId, orderRequest)));
     }
 
+    @Operation(
+            summary = "주문 내역 조회",
+            description = "사용자의 주문 내역을 조회합니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = OrderResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "사용자에 대한 주문 내역 조회에 성공했습니다.",
+                    response = OrderResponse[].class
+            )
+    )
     @GetMapping
     public ResponseEntity<ResponseBody<List<OrderResponse>>> getOrders(@CurrentUserId Long userId) {
         return ResponseEntity.ok(ResponseUtils.createSuccessResponse(orderService.getOrdersByUser(userId)));
     }
 
+    @Operation(
+            summary = "주문 정보 조회",
+            description = "주문 정보를 조회합니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = OrderResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "주문 정보 조회에 성공했습니다.",
+                    response = OrderResponse.class
+            )
+    )
     @GetMapping("/{id}")
     public ResponseEntity<ResponseBody<OrderResponse>> getOrder(@CurrentUserId Long userId,
                                                                 @PathVariable("id") Long orderId) {
         return ResponseEntity.ok(ResponseUtils.createSuccessResponse(orderService.getOrder(userId, orderId)));
     }
 
+    @Operation(
+            summary = "주문 취소",
+            description = "주문을 취소합니다."
+    )
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    status = HttpStatus.NO_CONTENT,
+                    description = "주문 취소에 성공했습니다."
+            )
+    )
     @DeleteMapping("{id}")
     public ResponseEntity<ResponseBody<Void>> cancel(@CurrentUserId Long userId,
                                                      @PathVariable("id") Long orderId) {
         orderService.cancelOrder(userId, orderId);
-        return ResponseEntity.ok(ResponseUtils.createSuccessResponse());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/kr/ac/kumoh/likelion/bouquet/order/domain/Order.java
+++ b/src/main/java/kr/ac/kumoh/likelion/bouquet/order/domain/Order.java
@@ -19,6 +19,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -43,18 +44,17 @@ public class Order {
 
     private LocalDateTime orderDate;
 
-    private Long totalPrice;
+    private Long totalPrice = 0L;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
-    private List<OrderDetail> orderDetails;
+    private List<OrderDetail> orderDetails = new ArrayList<>();
 
     @Builder
-    public Order(User user, FlowerShop shop, OrderStatus status, LocalDateTime orderDate, Long totalPrice) {
+    public Order(User user, FlowerShop shop, OrderStatus status, LocalDateTime orderDate) {
         this.user = user;
         this.shop = shop;
         this.status = status;
         this.orderDate = orderDate;
-        this.totalPrice = totalPrice;
     }
 
     public boolean isCancellable() {

--- a/src/main/java/kr/ac/kumoh/likelion/bouquet/order/service/OrderService.java
+++ b/src/main/java/kr/ac/kumoh/likelion/bouquet/order/service/OrderService.java
@@ -32,7 +32,7 @@ public class OrderService {
     private final UserRepository userRepository;
 
     @Transactional
-    public OrderResponse save(Long userId, OrderRequest request) {
+    public OrderResponse createOrder(Long userId, OrderRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
 
@@ -50,7 +50,7 @@ public class OrderService {
             Stock stock = stockRepository.findById(item.stockId())
                     .orElseThrow(() -> new ServiceException(ErrorCode.ORDER_NOT_FOUND));
 
-            if (!Objects.equals(stock.getShop().getId(), stock.getShop().getId())) {
+            if (!Objects.equals(stock.getShop().getId(), shop.getId())) {
                 throw new ServiceException(ErrorCode.SHOP_ID_MISMATCH);
             }
 

--- a/src/main/java/kr/ac/kumoh/likelion/bouquet/review/controller/ReviewController.java
+++ b/src/main/java/kr/ac/kumoh/likelion/bouquet/review/controller/ReviewController.java
@@ -1,4 +1,69 @@
 package kr.ac.kumoh.likelion.bouquet.review.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.ac.kumoh.likelion.bouquet.global.base.dto.ResponseBody;
+import kr.ac.kumoh.likelion.bouquet.global.base.dto.ResponseUtils;
+import kr.ac.kumoh.likelion.bouquet.global.config.swagger.SwaggerApiResponses;
+import kr.ac.kumoh.likelion.bouquet.global.config.swagger.SwaggerApiSuccessResponse;
+import kr.ac.kumoh.likelion.bouquet.global.jwt.annotation.CurrentUserId;
+import kr.ac.kumoh.likelion.bouquet.order.dto.OrderResponse;
+import kr.ac.kumoh.likelion.bouquet.review.dto.ReviewCreateRequest;
+import kr.ac.kumoh.likelion.bouquet.review.dto.ReviewResponse;
+import kr.ac.kumoh.likelion.bouquet.review.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "꽃집")
+@RestController
+@RequiredArgsConstructor
 public class ReviewController {
+    private final ReviewService reviewService;
+
+    @Operation(
+            summary = "리뷰 작성",
+            description = "꽃집에 대한 리뷰를 작성합니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = OrderResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "꽃집에 대한 리뷰 작성을 성공했습니다.",
+                    response = OrderResponse.class
+            )
+    )
+    @PostMapping("/shops/{shopId}/reviews")
+    public ResponseEntity<ResponseBody<ReviewResponse>> createReview(@CurrentUserId Long userId,
+                                                   @PathVariable("shopId") Long shopId,
+                                                   @RequestBody @Valid ReviewCreateRequest reviewCreateRequest) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ResponseUtils.createSuccessResponse(reviewService.createReview(userId, shopId, reviewCreateRequest)));
+    }
+
+    @Operation(
+            summary = "리뷰 목록 조회",
+            description = "꽃집에 대한 리뷰를 조회합니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = OrderResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "꽃집에 대한 리뷰 조회에 성공했습니다.",
+                    response = OrderResponse.class
+            )
+    )
+    @GetMapping("/shops/{shopId}/reviews")
+    public ResponseEntity<ResponseBody<List<ReviewResponse>>> getReviews(@PathVariable("shopId") Long shopId) {
+        return ResponseEntity.ok(ResponseUtils.createSuccessResponse(reviewService.getReviews(shopId)));
+    }
 }

--- a/src/main/java/kr/ac/kumoh/likelion/bouquet/review/domain/Review.java
+++ b/src/main/java/kr/ac/kumoh/likelion/bouquet/review/domain/Review.java
@@ -7,10 +7,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import kr.ac.kumoh.likelion.bouquet.shop.domain.FlowerShop;
 import kr.ac.kumoh.likelion.bouquet.user.domain.User;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "reviews")
@@ -21,7 +25,9 @@ public class Review {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long flowerShop;
+    @ManyToOne
+    @JoinColumn(name = "shop_id")
+    private FlowerShop shop;
 
     @ManyToOne
     @JoinColumn(name = "user_id")
@@ -30,4 +36,15 @@ public class Review {
     private Float stars;
 
     private String content;
+
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Review(FlowerShop shop, User user, Float stars, String content, LocalDateTime createdAt) {
+        this.shop = shop;
+        this.user = user;
+        this.stars = stars;
+        this.content = content;
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/kr/ac/kumoh/likelion/bouquet/review/dto/ReviewCreateRequest.java
+++ b/src/main/java/kr/ac/kumoh/likelion/bouquet/review/dto/ReviewCreateRequest.java
@@ -1,0 +1,7 @@
+package kr.ac.kumoh.likelion.bouquet.review.dto;
+
+public record ReviewCreateRequest(
+        Float stars,
+        String content
+) {
+}

--- a/src/main/java/kr/ac/kumoh/likelion/bouquet/review/dto/ReviewResponse.java
+++ b/src/main/java/kr/ac/kumoh/likelion/bouquet/review/dto/ReviewResponse.java
@@ -1,0 +1,23 @@
+package kr.ac.kumoh.likelion.bouquet.review.dto;
+
+import kr.ac.kumoh.likelion.bouquet.review.domain.Review;
+
+import java.time.LocalDateTime;
+
+public record ReviewResponse(
+        Long userId,
+        String name,
+        String profileImageUrl,
+        LocalDateTime createdAt,
+        Float stars,
+        String content
+) {
+    public static ReviewResponse from(Review review) {
+        return new ReviewResponse(review.getUser().getId(),
+                review.getUser().getName(),
+                review.getUser().getProfileImageUrl(),
+                review.getCreatedAt(),
+                review.getStars(),
+                review.getContent());
+    }
+}

--- a/src/main/java/kr/ac/kumoh/likelion/bouquet/review/repository/ReviewRepository.java
+++ b/src/main/java/kr/ac/kumoh/likelion/bouquet/review/repository/ReviewRepository.java
@@ -1,15 +1,13 @@
 package kr.ac.kumoh.likelion.bouquet.review.repository;
 
 import kr.ac.kumoh.likelion.bouquet.review.domain.Review;
+import kr.ac.kumoh.likelion.bouquet.shop.domain.FlowerShop;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
+import java.util.List;
+
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-    /**
-     * 특정 꽃집의 리뷰 개수를 반환합니다.
-     * @param flowerShopId 꽃집 ID
-     * @return 리뷰 개수
-     */
-    long countByFlowerShop(Long flowerShopId);
+    List<Review> findByShop(FlowerShop shop);
+
+    long countByShop(FlowerShop shop);
 }

--- a/src/main/java/kr/ac/kumoh/likelion/bouquet/review/service/ReviewService.java
+++ b/src/main/java/kr/ac/kumoh/likelion/bouquet/review/service/ReviewService.java
@@ -1,0 +1,59 @@
+package kr.ac.kumoh.likelion.bouquet.review.service;
+
+import kr.ac.kumoh.likelion.bouquet.global.base.exception.ErrorCode;
+import kr.ac.kumoh.likelion.bouquet.global.base.exception.ServiceException;
+import kr.ac.kumoh.likelion.bouquet.review.domain.Review;
+import kr.ac.kumoh.likelion.bouquet.review.dto.ReviewCreateRequest;
+import kr.ac.kumoh.likelion.bouquet.review.dto.ReviewResponse;
+import kr.ac.kumoh.likelion.bouquet.review.repository.ReviewRepository;
+import kr.ac.kumoh.likelion.bouquet.shop.domain.FlowerShop;
+import kr.ac.kumoh.likelion.bouquet.shop.repository.ShopRepository;
+import kr.ac.kumoh.likelion.bouquet.user.domain.User;
+import kr.ac.kumoh.likelion.bouquet.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+    private final UserRepository userRepository;
+    private final ShopRepository shopRepository;
+    private final ReviewRepository reviewRepository;
+
+    @Transactional
+    public ReviewResponse createReview(Long userId, Long shopId, ReviewCreateRequest reviewCreateRequest) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.USER_NOT_FOUND));
+
+        FlowerShop shop = shopRepository.findById(shopId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.SHOP_NOT_FOUND));
+
+        Review review = Review.builder()
+                .shop(shop)
+                .user(user)
+                .stars(reviewCreateRequest.stars())
+                .content(reviewCreateRequest.content())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        reviewRepository.save(review);
+
+        return ReviewResponse.from(review);
+    }
+
+    public List<ReviewResponse> getReviews(Long shopId) {
+        FlowerShop shop = shopRepository.findById(shopId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.SHOP_NOT_FOUND));
+
+        List<Review> reviews = reviewRepository.findByShop(shop);
+
+        return reviews.stream()
+                .map(ReviewResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/kr/ac/kumoh/likelion/bouquet/shop/controller/ShopController.java
+++ b/src/main/java/kr/ac/kumoh/likelion/bouquet/shop/controller/ShopController.java
@@ -1,5 +1,13 @@
 package kr.ac.kumoh.likelion.bouquet.shop.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.ac.kumoh.likelion.bouquet.global.config.swagger.SwaggerApiResponses;
+import kr.ac.kumoh.likelion.bouquet.global.config.swagger.SwaggerApiSuccessResponse;
+import kr.ac.kumoh.likelion.bouquet.order.dto.OrderResponse;
 import kr.ac.kumoh.likelion.bouquet.shop.dto.ShopCreateRequest;
 import kr.ac.kumoh.likelion.bouquet.shop.dto.ShopDetailResponse;
 import kr.ac.kumoh.likelion.bouquet.shop.dto.ShopSummaryResponse;
@@ -11,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "꽃집")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/shops")
@@ -18,12 +27,34 @@ public class ShopController {
 
     private final ShopService shopService;
 
+    @Operation(
+            summary = "꽃집 목록 조회",
+            description = "꽃집 목록을 조회합니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ShopSummaryResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "꽃집 목록 조회에 성공했습니다.",
+                    response = ShopSummaryResponse[].class
+            )
+    )
     @GetMapping
     public ResponseEntity<List<ShopSummaryResponse>> getShops(@RequestParam(required = false) String name) {
         List<ShopSummaryResponse> shops = shopService.findShops(name);
         return ResponseEntity.ok(shops);
     }
 
+    @Operation(
+            summary = "꽃집 조회",
+            description = "꽃집 정보를 조회합니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ShopDetailResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "꽃집 정보 조회에 성공했습니다.",
+                    response = ShopDetailResponse.class
+            )
+    )
     @GetMapping("/{shopId}")
     public ResponseEntity<ShopDetailResponse> getShopDetail(@PathVariable Long shopId) {
         ShopDetailResponse shop = shopService.findShopById(shopId);

--- a/src/main/java/kr/ac/kumoh/likelion/bouquet/shop/service/ShopService.java
+++ b/src/main/java/kr/ac/kumoh/likelion/bouquet/shop/service/ShopService.java
@@ -55,7 +55,7 @@ public class ShopService {
                 .orElseThrow(() -> new ServiceException(ErrorCode.SHOP_NOT_FOUND));
 
         // reviewRepository를 통해 실제 리뷰 개수를 조회
-        long reviewCount = reviewRepository.countByFlowerShop(shopId);
+        long reviewCount = reviewRepository.countByShop(shop);
 
         return ShopDetailResponse.builder()
                 .id(shop.getId())

--- a/src/main/java/kr/ac/kumoh/likelion/bouquet/stock/controller/StockController.java
+++ b/src/main/java/kr/ac/kumoh/likelion/bouquet/stock/controller/StockController.java
@@ -1,26 +1,44 @@
 package kr.ac.kumoh.likelion.bouquet.stock.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.ac.kumoh.likelion.bouquet.global.base.dto.ResponseBody;
 import kr.ac.kumoh.likelion.bouquet.global.base.dto.ResponseUtils;
+import kr.ac.kumoh.likelion.bouquet.global.config.swagger.SwaggerApiResponses;
+import kr.ac.kumoh.likelion.bouquet.global.config.swagger.SwaggerApiSuccessResponse;
+import kr.ac.kumoh.likelion.bouquet.shop.dto.ShopDetailResponse;
 import kr.ac.kumoh.likelion.bouquet.stock.dto.StockResponse;
 import kr.ac.kumoh.likelion.bouquet.stock.service.StockService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @Tag(name = "꽃집")
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/shops")
 public class StockController {
     private final StockService stockService;
 
+    @Operation(
+            summary = "꽃집 판매 상품 목록 조회",
+            description = "꽃집에서 판매하는 상품 목록을 조회합니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = StockResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "꽃집 판매 상품 목록 조회에 성공했습니다.",
+                    response = StockResponse[].class
+            )
+    )
     @GetMapping("/{id}/stocks")
     public ResponseEntity<ResponseBody<List<StockResponse>>> getStocks(@PathVariable("id") Long stockId) {
         return ResponseEntity.ok(ResponseUtils.createSuccessResponse(stockService.getStocks(stockId)));


### PR DESCRIPTION
## 🚩 작업 요약
꽃집 주문 및 리뷰 도메인 기능 추가, 공통 응답 포맷 적용, Swagger 명세 개선

**1️⃣ 주문 및 리뷰 도메인 구현**
- 주문 생성, 조회, 취소 및 리뷰 작성, 조회 API 구현했습니다.

**2️⃣ Swagger 문서 명세 개선 및 Controller 반환 타입 수정**
- Swagger 문서를 필요한 모든 API에 추가하였습니다.
- ResponseBody<> 타입을 추가하여 응답 반환 시 감싸 통일된 응답을 반환하도록 했습니다.

## 📋 요구 사항
- 평균 별점이나 총 리뷰 수도 반환할 수 있도록 수정하겠습니다.
